### PR TITLE
🐛 Fix: Page 가 비어있을때 return 하지 않는 버그 수정

### DIFF
--- a/src/main/java/project/masil/community/service/ClubPostService.java
+++ b/src/main/java/project/masil/community/service/ClubPostService.java
@@ -164,6 +164,10 @@ public class ClubPostService {
     Page<ClubPost> clubPosts = clubPostRepository.findByEventPostOrderByCreatedAtDesc(eventPost,
         pageable);
 
+    if (clubPosts.isEmpty()) {
+      return Page.empty(pageable);
+    }
+
     //  현재 페이지에 담긴 이벤트들의 ID만 뽑아옴 (배치 처리를 위한 준비)
     List<Long> postIds = clubPosts.getContent().stream().map(ClubPost::getId).toList();
 


### PR DESCRIPTION
## 📌 PR 요약 (하나 이상 선택해주세요)

- [ ]  Page 가 비어있을때 return 하지 않는 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 💡 주요 변경사항

- ***

## 🔍 관련 이슈

- #

---

## 🌿 브랜치 정보

- 병합 대상 브랜치: main
- 현재 작업 브랜치: feat/jaeyeon/ai

---

## 🧪 테스트 방법

- ***

## ⚠️ 주의사항

-
